### PR TITLE
Create assets to build prefs and memory databases

### DIFF
--- a/Assets/UGF.Module.Database.Runtime.Tests/New Database Module Asset.asset
+++ b/Assets/UGF.Module.Database.Runtime.Tests/New Database Module Asset.asset
@@ -15,3 +15,7 @@ MonoBehaviour:
   m_databases:
   - m_guid: 3e6a4fca725fb0d48bd9f647cbe54ea8
     m_asset: {fileID: 11400000, guid: 3e6a4fca725fb0d48bd9f647cbe54ea8, type: 2}
+  - m_guid: da17236dda38728469d68b057bb1b14c
+    m_asset: {fileID: 11400000, guid: da17236dda38728469d68b057bb1b14c, type: 2}
+  - m_guid: df95caa1d9990a5439ebb056c8b97df9
+    m_asset: {fileID: 11400000, guid: df95caa1d9990a5439ebb056c8b97df9, type: 2}

--- a/Assets/UGF.Module.Database.Runtime.Tests/New Memory Database Asset.asset
+++ b/Assets/UGF.Module.Database.Runtime.Tests/New Memory Database Asset.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec70eb0967464298a1368719ba264734, type: 3}
+  m_Name: New Memory Database Asset
+  m_EditorClassIdentifier: 

--- a/Assets/UGF.Module.Database.Runtime.Tests/New Memory Database Asset.asset.meta
+++ b/Assets/UGF.Module.Database.Runtime.Tests/New Memory Database Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df95caa1d9990a5439ebb056c8b97df9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Module.Database.Runtime.Tests/New Prefs Database Asset.asset
+++ b/Assets/UGF.Module.Database.Runtime.Tests/New Prefs Database Asset.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b3ced961719746f08fecea6d964e4364, type: 3}
+  m_Name: New Prefs Database Asset
+  m_EditorClassIdentifier: 

--- a/Assets/UGF.Module.Database.Runtime.Tests/New Prefs Database Asset.asset.meta
+++ b/Assets/UGF.Module.Database.Runtime.Tests/New Prefs Database Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: da17236dda38728469d68b057bb1b14c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Module.Database/Runtime/Memory.meta
+++ b/Packages/UGF.Module.Database/Runtime/Memory.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8205ebe515214605a6f44f73a1396aba
+timeCreated: 1626111392

--- a/Packages/UGF.Module.Database/Runtime/Memory/MemoryDatabaseAsset.cs
+++ b/Packages/UGF.Module.Database/Runtime/Memory/MemoryDatabaseAsset.cs
@@ -1,0 +1,15 @@
+﻿using UGF.Database.Runtime;
+using UGF.Database.Runtime.Memory;
+using UnityEngine;
+
+namespace UGF.Module.Database.Runtime.Memory
+{
+    [CreateAssetMenu(menuName = "Unity Game Framework/Database/Database Memory", order = 2000)]
+    public class MemoryDatabaseAsset : DatabaseBuilderAsset
+    {
+        protected override IDatabase OnBuild()
+        {
+            return new MemoryDatabase();
+        }
+    }
+}

--- a/Packages/UGF.Module.Database/Runtime/Memory/MemoryDatabaseAsset.cs.meta
+++ b/Packages/UGF.Module.Database/Runtime/Memory/MemoryDatabaseAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ec70eb0967464298a1368719ba264734
+timeCreated: 1626111395

--- a/Packages/UGF.Module.Database/Runtime/Prefs.meta
+++ b/Packages/UGF.Module.Database/Runtime/Prefs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f9a7a8c7a3894406a111c0775de31326
+timeCreated: 1626111363

--- a/Packages/UGF.Module.Database/Runtime/Prefs/PrefsDatabaseAsset.cs
+++ b/Packages/UGF.Module.Database/Runtime/Prefs/PrefsDatabaseAsset.cs
@@ -1,0 +1,15 @@
+﻿using UGF.Database.Runtime;
+using UGF.Database.Runtime.Prefs;
+using UnityEngine;
+
+namespace UGF.Module.Database.Runtime.Prefs
+{
+    [CreateAssetMenu(menuName = "Unity Game Framework/Database/Database Prefs", order = 2000)]
+    public class PrefsDatabaseAsset : DatabaseBuilderAsset
+    {
+        protected override IDatabase OnBuild()
+        {
+            return new PrefsDatabase();
+        }
+    }
+}

--- a/Packages/UGF.Module.Database/Runtime/Prefs/PrefsDatabaseAsset.cs.meta
+++ b/Packages/UGF.Module.Database/Runtime/Prefs/PrefsDatabaseAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b3ced961719746f08fecea6d964e4364
+timeCreated: 1626111303

--- a/Packages/UGF.Module.Database/package.json
+++ b/Packages/UGF.Module.Database/package.json
@@ -19,7 +19,7 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.ugf.application": "8.0.0-preview.4",
-    "com.ugf.database": "1.0.0-preview.1"
+    "com.ugf.application": "8.0.0-preview.8",
+    "com.ugf.database": "1.0.0-preview.2"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.4",
-    "com.unity.test-framework": "1.1.22"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.27"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -103,16 +103,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.4",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.1"
+        "com.unity.ext.nunit": "1.0.6"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.22",
+      "version": "1.1.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "8.0.0-preview.4",
+      "version": "8.0.0-preview.8",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
         "com.ugf.description": "2.0.0",
         "com.ugf.runtimetools": "2.0.0",
-        "com.ugf.logs": "5.1.3"
+        "com.ugf.logs": "5.1.4"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -20,16 +20,17 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.customsettings": {
-      "version": "3.4.0",
+      "version": "3.4.1",
       "depth": 4,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0",
         "com.ugf.editortools": "1.7.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.database": {
-      "version": "1.0.0-preview.1",
+      "version": "1.0.0-preview.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -38,12 +39,12 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.defines": {
-      "version": "2.1.2",
+      "version": "2.1.4",
       "depth": 3,
       "source": "registry",
       "dependencies": {
-        "com.ugf.customsettings": "3.4.0",
-        "com.ugf.editortools": "1.10.0"
+        "com.ugf.customsettings": "3.4.1",
+        "com.ugf.editortools": "1.11.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -57,7 +58,7 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
-      "version": "1.10.0",
+      "version": "1.11.0",
       "depth": 4,
       "source": "registry",
       "dependencies": {},
@@ -71,11 +72,11 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.logs": {
-      "version": "5.1.3",
+      "version": "5.1.4",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.ugf.defines": "2.1.2"
+        "com.ugf.defines": "2.1.4"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -84,8 +85,8 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "8.0.0-preview.4",
-        "com.ugf.database": "1.0.0-preview.1"
+        "com.ugf.application": "8.0.0-preview.8",
+        "com.ugf.database": "1.0.0-preview.2"
       }
     },
     "com.ugf.runtimetools": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.0b7
-m_EditorVersionWithRevision: 2021.1.0b7 (02180fe17a0e)
+m_EditorVersion: 2021.1.7f1
+m_EditorVersionWithRevision: 2021.1.7f1 (d91830b65d9b)


### PR DESCRIPTION
- Update dependencies: `com.ugf.application` to `8.0.0-preview.8` and `com.ugf.database` to `1.0.0-preview.2` version.
- Add `MemoryDatabaseAsset` and `PrefsDatabaseAsset` asset to build `MemoryDatabase` and `PrefsDatabase` databases.